### PR TITLE
Fix 'res' may be used uninitialized

### DIFF
--- a/component/pl_uart_base.cpp
+++ b/component/pl_uart_base.cpp
@@ -129,7 +129,7 @@ esp_err_t Uart::Read (void* dest, size_t size) {
   if (!size)
     return ESP_OK;
   
-  int res;
+  int res = 0;
   if (dest)
     size -= (res = uart_read_bytes (port, dest, size, readTimeout));
   else {


### PR DESCRIPTION
Fixes this error
![image](https://github.com/plasmapper/uart-esp-cpp/assets/38137329/6139afbf-e6b8-45c5-9e4c-6f24025bba3e)
